### PR TITLE
Annotate custom tasks and extensions

### DIFF
--- a/src/main/java/com/shopify/syrup/extensions/SyrupModelsExtensions.kt
+++ b/src/main/java/com/shopify/syrup/extensions/SyrupModelsExtensions.kt
@@ -1,13 +1,14 @@
 package com.shopify.syrup.extensions
 
+import org.gradle.api.tasks.Input
 import org.yaml.snakeyaml.Yaml
 import java.io.File
 
-open class SchemaConfig(val name: String) {
-    var config: String = ""
-    var graphql: String = ""
-    var format: Boolean = false
-    var generateReport: Boolean = false
+open class SchemaConfig(@Input val name: String) {
+    @Input var config: String = ""
+    @Input var graphql: String = ""
+    @Input var format: Boolean = false
+    @Input var generateReport: Boolean = false
 
     companion object {
         const val NAME = "syrup"

--- a/src/main/java/com/shopify/syrup/extensions/SyrupSupportExtensions.kt
+++ b/src/main/java/com/shopify/syrup/extensions/SyrupSupportExtensions.kt
@@ -2,10 +2,12 @@ package com.shopify.syrup.extensions
 
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFile
 import java.io.File
 
 open class SyrupSupportExtensions(project: Project) {
-    val configFile: Property<File> = project.objects.property(File::class.java)
+
+    @InputFile val configFile: Property<File> = project.objects.property(File::class.java)
 
     companion object {
         const val NAME = "syrupSupport"

--- a/src/main/java/com/shopify/syrup/tasks/CleanGenerateModelsTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/CleanGenerateModelsTask.kt
@@ -3,13 +3,14 @@ package com.shopify.syrup.tasks
 import com.shopify.syrup.extensions.SchemaConfig
 import com.shopify.syrup.extensions.moduleNameToSrcPath
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 
 open class CleanGenerateModelsTask : DefaultTask() {
 
-    lateinit var schemaConfig: SchemaConfig
+    @Nested lateinit var schemaConfig: SchemaConfig
 
     @TaskAction
     fun action() {

--- a/src/main/java/com/shopify/syrup/tasks/CreateModelsDirectoriesTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/CreateModelsDirectoriesTask.kt
@@ -3,11 +3,12 @@ package com.shopify.syrup.tasks
 import com.shopify.syrup.extensions.SchemaConfig
 import com.shopify.syrup.extensions.moduleNameToSrcPath
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class CreateModelsDirectoriesTask : DefaultTask() {
-    lateinit var schemaConfig: SchemaConfig
+    @Nested lateinit var schemaConfig: SchemaConfig
 
     @TaskAction
     fun action() {

--- a/src/main/java/com/shopify/syrup/tasks/DeleteTemporaryFilesTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/DeleteTemporaryFilesTask.kt
@@ -3,12 +3,13 @@ package com.shopify.syrup.tasks
 import com.shopify.syrup.extensions.SchemaConfig
 import com.shopify.syrup.SyrupPlugin
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class DeleteTemporaryFilesTask : DefaultTask() {
 
-    lateinit var schemaConfig: SchemaConfig
+    @Nested lateinit var schemaConfig: SchemaConfig
 
     @TaskAction
     fun action() {

--- a/src/main/java/com/shopify/syrup/tasks/FormatModelsTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/FormatModelsTask.kt
@@ -3,13 +3,14 @@ package com.shopify.syrup.tasks
 import com.shopify.syrup.extensions.SchemaConfig
 import com.shopify.syrup.extensions.moduleNameToSrcPath
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import java.io.ByteArrayOutputStream
 import java.io.File
 
 open class FormatModelsTask : DefaultTask() {
 
-    lateinit var schemaConfig: SchemaConfig
+    @Nested lateinit var schemaConfig: SchemaConfig
 
     @TaskAction
     fun action() {

--- a/src/main/java/com/shopify/syrup/tasks/GenerateModelsTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/GenerateModelsTask.kt
@@ -4,13 +4,14 @@ import com.shopify.syrup.extensions.SchemaConfig
 import com.shopify.syrup.SyrupPlugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import java.io.ByteArrayOutputStream
 import java.io.File
 
 open class GenerateModelsTask : DefaultTask() {
 
-    lateinit var schemaConfig: SchemaConfig
+    @Nested lateinit var schemaConfig: SchemaConfig
 
     @TaskAction
     fun action() {

--- a/src/main/java/com/shopify/syrup/tasks/GenerateSupportFilesTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/GenerateSupportFilesTask.kt
@@ -4,12 +4,14 @@ import com.shopify.syrup.extensions.SyrupSupportExtensions
 import com.shopify.syrup.SyrupPlugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import java.io.ByteArrayOutputStream
 import java.io.File
 
 open class GenerateSupportFilesTask : DefaultTask() {
-    lateinit var extension: SyrupSupportExtensions
+
+    @Nested lateinit var extension: SyrupSupportExtensions
 
     @TaskAction
     fun action() {

--- a/src/main/java/com/shopify/syrup/tasks/MoveModelsTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/MoveModelsTask.kt
@@ -4,12 +4,13 @@ import com.shopify.syrup.extensions.SchemaConfig
 import com.shopify.syrup.extensions.moduleNameToSrcPath
 import com.shopify.syrup.SyrupPlugin
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class MoveModelsTask : DefaultTask() {
 
-    lateinit var schemaConfig: SchemaConfig
+    @Nested lateinit var schemaConfig: SchemaConfig
 
     @TaskAction
     fun action() {


### PR DESCRIPTION
Upgrading to Gradle 6.x `shadowJar` continued to compile the plugin fine, but `build` broke.  

As per https://docs.gradle.org/6.2.1/userguide/more_about_tasks.html#sec:task_input_output_annotations this PR fixes `build` by annotating our tasks and extensions appropriately.

Tophat instructions:
1. `./gradlew build` is successful