### PR TITLE
Add experimental flag to enable indentation formatting

### DIFF
--- a/src/main/java/com/shopify/syrup/tasks/FormatModelsTask.kt
+++ b/src/main/java/com/shopify/syrup/tasks/FormatModelsTask.kt
@@ -27,6 +27,8 @@ open class FormatModelsTask : DefaultTask() {
 
             it.args = listOf(
                 "-F",
+                "--experimental",
+                "--disabled_rules=no-wildcard-imports",
                 schemaConfig.moduleNameToSrcPath(project.projectDir).path + ALL_KOTLIN_SRC
             )
         }


### PR DESCRIPTION
Make use of experimental flag to enable indentation to auto correct.

Looks safe enough. See
https://github.com/pinterest/ktlint/blob/master/README.md#experimental-rules

Also disable * import rule.