### PR TITLE
Add plugin for publishing to Bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,46 @@
-group 'com.shopify.syrup'
-version '0.2'
+def VERSION_NAME = "0.2.1"
 
 buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5"
     }
 }
 
-apply plugin: 'java-gradle-plugin'
 apply plugin: 'kotlin'
+apply plugin: 'java-gradle-plugin'
+apply plugin: 'maven'
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'com.jfrog.bintray'
+
+ext {
+    pom = [
+            publishedGroupId  : 'com.shopify.syrup',
+            artifact          : 'syrup-gradle',
+            libraryName       : 'syrup-gradle',
+            libraryDescription: 'A Gradle plugin for generating GraphQL models with Syrup.',
+            siteUrl           : 'https://github.com/Shopify/syrup-gradle',
+            gitUrl            : 'https://github.com/Shopify/syrup-gradle.git',
+            licenseName       : 'The MIT License',
+            licenseUrl        : 'https://opensource.org/licenses/MIT'
+    ]
+
+    bintray = [
+            org        : 'shopify',
+            repo       : 'shopify-java',
+            name       : 'syrup-gradle',
+            allLicenses: ["MIT"]
+    ]
+}
+
+group pom.publishedGroupId
+version VERSION_NAME
 
 repositories {
     google()
@@ -47,3 +73,58 @@ task publishBinary(type: Copy) {
     }
     into 'lib'
 }
+
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                groupId project.ext.pom.publishedGroupId
+                artifactId project.ext.pom.artifact
+
+                name project.ext.pom.libraryName
+                description project.ext.pom.libraryDescription
+                url project.ext.pom.siteUrl
+
+                licenses {
+                    license {
+                        name project.ext.pom.licenseName
+                        url project.ext.pom.licenseUrl
+                    }
+                }
+
+                scm {
+                    connection project.ext.pom.gitUrl
+                    developerConnection project.ext.pom.gitUrl
+                    url project.ext.pom.siteUrl
+                }
+            }
+        }
+    }
+}
+
+artifacts {
+    archives shadowJar
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+
+    configurations = ['archives']
+
+    pkg {
+        userOrg = project.ext.bintray.org
+        repo = project.ext.bintray.repo
+        name = project.ext.bintray.name
+        desc = project.ext.pom.libraryDescription
+        websiteUrl = project.ext.pom.siteUrl
+        vcsUrl = project.ext.pom.gitUrl
+        licenses = project.ext.bintray.allLicenses
+        version {
+            desc = project.ext.pom.libraryDescription
+        }
+        publish = true
+    }
+}
+
+bintrayUpload.dependsOn(shadowJar)


### PR DESCRIPTION
Allows someone with a Bintray username and API key to successfully run  `./gradlew bintrayUpload` and publish a release.